### PR TITLE
Support Java 7 by removing an unused Java 8 import

### DIFF
--- a/theme/src/com/sysgears/theme/ResourceMapper.groovy
+++ b/theme/src/com/sysgears/theme/ResourceMapper.groovy
@@ -4,8 +4,6 @@ import com.sysgears.grain.taglib.Site
 import com.sysgears.theme.pagination.Paginator
 import org.joda.time.DateTime
 
-import java.time.format.DateTimeFormatter
-
 /**
  * Change pages urls and extend models.
  */


### PR DESCRIPTION
Building a site with Java 7 failed, apparently due to a single import statement in ResourceMapper.groovy. 

Grain aims to support Java 7+ and I was able to build successfully with Java 7 when this import statement is removed.